### PR TITLE
Unterschriftsberechtigung angepasst

### DIFF
--- a/coredump/statuten.tex
+++ b/coredump/statuten.tex
@@ -232,8 +232,11 @@
 \section{Unterschrift, Haftung}
 
 \ol
-	\li Der Verein wird verpflichtet durch die Kollektivunterschrift des
-	Präsidenten zusammen mit einem weiteren Mitglied des Vorstandes.
+	\li Der Verein wird verpflichtet durch die Einzelunterschrift, ausgenommen das
+	Eingehen von Dauerschuldverhältnissen kollektiv durch den Präsidenten zusammen
+	mit einem weiteren Mitglied des Vorstandes.
+	\li Die Aufnahme von Krediten sowie das Leisten von Bürgschaften bedürfen
+	zusätzlich der Bewilligung durch die Generalversammlung.
 	\li Für die Schulden des Vereins haftet nur das Vereinsvermögen. Eine
 	persönliche Haftung der Mitglieder ist ausgeschlossen.
 \lo


### PR DESCRIPTION
Statuten-Änderungsantrag für die nächste GV.

Begründung: Für einfache Verträge (Beispiele: Frühlingsfest, Internetabo) ist
die Unterschrift zu Zweien häufig etwas mühsam. Einzelunterschrift sollte für
sowas ausreichen, mit Ausnahme von wichtigen Verträgen wie Schuldverhältnissen
und Ähnlichem.

RFC, @schmijos @rnestler @Luz.
