### PR TITLE
Ersetze 'Generalversammlung' mit 'Vereinsversammlung'

### DIFF
--- a/coredump/statuten.tex
+++ b/coredump/statuten.tex
@@ -169,7 +169,7 @@
 	Austrittsschreiben muss schriftlich an den Vorstand gerichtet werden.
 	\li Ein Mitglied kann jederzeit ohne Grundangabe aus dem Verein ausgeschlossen
 	werden. Der Vorstand fällt den Ausschlussentscheid; das Mitglied kann den
-	Ausschlussentscheid an die Generalversammlung weiterziehen.
+	Ausschlussentscheid an die Vereinsversammlung weiterziehen.
 \lo
 
 
@@ -178,20 +178,20 @@
 \ol
 	\li Die Organe des Vereins sind:
 		\ol
-			\li die Generalversammlung
+			\li die Vereinsversammlung
 			\li der Vorstand
 		\lo
 \lo
 
 
-\section{Die Generalversammlung}
+\section{Die Vereinsversammlung}
 
 \ol
-	\li Das oberste Organ des Vereins ist die Generalversammlung. Eine ordentliche
-	Generalversammlung findet jährlich statt.
-	\li Zur Generalversammlung werden die Mitglieder drei Wochen zum voraus
+	\li Das oberste Organ des Vereins ist die Vereinsversammlung. Eine ordentliche
+	Vereinsversammlung findet jährlich statt.
+	\li Zur Vereinsversammlung werden die Mitglieder drei Wochen zum voraus
 	schriftlich eingeladen, unter Beilage der Traktandenliste.
-	\li Die Generalversammlung hat die folgenden unentziehbaren Aufgaben:
+	\li Die Vereinsversammlung hat die folgenden unentziehbaren Aufgaben:
 		\ol
 			\li Wahl bzw. Abwahl des Vorstandes
 			\li Festsetzung und Änderung der Statuten
@@ -200,10 +200,10 @@
 			\li Festsetzung der Mitgliederbeiträge
 			\li Behandlung der Ausschlussrekurse
 		\lo
-	\li An der Generalversammlung besitzt jedes Aktivmitglied eine Stimme; die
+	\li An der Vereinsversammlung besitzt jedes Aktivmitglied eine Stimme; die
 	Beschlussfassung erfolgt mit einfachem Mehr.
 	\li Bei Stimmengleichheit entscheidet der Präsident mit Stichentscheid.
-	\li Passivmitglieder werden zur Generalversammlung eingeladen, besitzen jedoch
+	\li Passivmitglieder werden zur Vereinsversammlung eingeladen, besitzen jedoch
 	kein Stimmrecht.
 \lo
 
@@ -236,7 +236,7 @@
 	Eingehen von Dauerschuldverhältnissen kollektiv durch den Präsidenten zusammen
 	mit einem weiteren Mitglied des Vorstandes.
 	\li Die Aufnahme von Krediten sowie das Leisten von Bürgschaften bedürfen
-	zusätzlich der Bewilligung durch die Generalversammlung.
+	zusätzlich der Bewilligung durch die Vereinsversammlung.
 	\li Für die Schulden des Vereins haftet nur das Vereinsvermögen. Eine
 	persönliche Haftung der Mitglieder ist ausgeschlossen.
 \lo

--- a/coredump/statuten.tex
+++ b/coredump/statuten.tex
@@ -222,7 +222,7 @@
 
 \ol
 	\li Der Mitgliederbeitrag wird jährlich erhoben. Die Höhe des
-	Mitgliederbeitrags wird jährlich von der Generalversammlung festgelegt.
+	Mitgliederbeitrags wird jährlich von der Vereinsversammlung festgelegt.
 	\li Tritt ein Mitglied während des Vereinsjahrs bei, wird der
 	Mitgliederbeitrag pro rata für die verbleibenden Monate erhoben.
 	\li Das Vereinsjahr beginnt am 1. Oktober und endet am 30. September.
@@ -253,7 +253,7 @@
 \section{Auflösung des Vereins}
 
 \ol
-	\li Die Auflösung des Vereins kann an einer Generalversammlung mit absoluter
+	\li Die Auflösung des Vereins kann an einer Vereinsversammlung mit absoluter
 	Mehrheit der anwesenden stimmberechtigten Mitglieder beschlossen werden.
 	\li Bei einer Auflösung des Vereins fällt das Vereinsvermögen an eine
 	Institution, welche den gleichen oder einen ähnlichen Zweck verfolgt.

--- a/coredump/statuten.tex
+++ b/coredump/statuten.tex
@@ -222,7 +222,7 @@
 
 \ol
 	\li Der Mitgliederbeitrag wird jährlich erhoben. Die Höhe des
-	Mitgliederbeitrags wird jährlich von der Vereinsversammlung festgelegt.
+	Mitgliederbeitrags wird jährlich von der Generalversammlung festgelegt.
 	\li Tritt ein Mitglied während des Vereinsjahrs bei, wird der
 	Mitgliederbeitrag pro rata für die verbleibenden Monate erhoben.
 	\li Das Vereinsjahr beginnt am 1. Oktober und endet am 30. September.
@@ -253,7 +253,7 @@
 \section{Auflösung des Vereins}
 
 \ol
-	\li Die Auflösung des Vereins kann an einer Vereinsversammlung mit absoluter
+	\li Die Auflösung des Vereins kann an einer Generalversammlung mit absoluter
 	Mehrheit der anwesenden stimmberechtigten Mitglieder beschlossen werden.
 	\li Bei einer Auflösung des Vereins fällt das Vereinsvermögen an eine
 	Institution, welche den gleichen oder einen ähnlichen Zweck verfolgt.


### PR DESCRIPTION
Es war ein wenig verwirrend, dass von Vereinsversammlung und
Generalversammlung gesprochen wurde obwohl immer Vereinsversammlung
gemeint war.
Fixes #5 