### PR TITLE
Chaostreff Coredump: Grammatikalisch notwendiges Komma eingefügt

### DIFF
--- a/cccch/statuten.tex
+++ b/cccch/statuten.tex
@@ -199,7 +199,7 @@
 	Spenden und Legaten.
 	\li Der Mitgliederbeitrag wird jährlich erhoben. Die Höhe des
 	Mitgliederbeitrags wird jährlich von der Generalversammlung festgelegt.
-	\li Für Personen, die dem Verein vor dem 1. August beitreten ist der volle
+	\li Für Personen, die dem Verein vor dem 1. August beitreten, ist der volle
 	Mitgliederbeitrag für das laufende Jahr zu erstatten. Tritt eine Person aber
 	nach dem 1. August bei, so muss für das laufende Jahr kein Mitgliederbeitrag
 	entrichtet werden.


### PR DESCRIPTION
Grammatikalisch notwendiges Komma eingefügt, um den eingeschobenen Teilsatz "die dem Verein vor dem 1. August beitreten" zu begrenzen.